### PR TITLE
feat: add updatecli 0.17.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,21 +3,14 @@
 # Alpine is used by default for fast and ligthweight customization
 ARG GO_VERSION=1.17.6
 ARG PACKER_VERSION=1.7.8
-FROM golang:"${GO_VERSION}-alpine" as gosource
-FROM hashicorp/packer:"${PACKER_VERSION}" as packersource
+ARG UPDATECLI_VERSION=v0.17.2
+FROM golang:"${GO_VERSION}-alpine" AS gosource
+FROM hashicorp/packer:"${PACKER_VERSION}" AS packersource
+FROM updatecli/updatecli:${UPDATECLI_VERSION} AS updatecli
 
 FROM jenkins/inbound-agent:4.11-1-alpine-jdk11
+
 USER root
-
-COPY --from=gosource /usr/local/go/ /usr/local/go/
-# Configure Go
-ENV PATH /usr/local/go/bin/:$PATH
-
-COPY --from=packersource /bin/packer /usr/local/bin/
-
-## Repeating the ARG to add it into the scope of this image
-ARG GO_VERSION=1.17.6
-ARG PACKER_VERSION=1.7.8
 
 RUN apk add --no-cache \
   # To allow easier CLI completion + running shell scripts with array support
@@ -39,12 +32,24 @@ RUN apk add --no-cache \
   # jq for the yaml in /cleanup/*.sh
   yq=~4
 
+## bash need to be installed for this instruction to work as expected
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Golang (for terratest)
+COPY --from=gosource /usr/local/go/ /usr/local/go/
+ENV PATH /usr/local/go/bin/:$PATH
+
+# Packer
+COPY --from=packersource /bin/packer /usr/local/bin/
+
+## Repeating the ARG to add it into the scope of this image
+ARG GO_VERSION=1.17.6
+ARG PACKER_VERSION=1.7.8
+ARG UPDATECLI_VERSION=v0.17.2
+
 ## Install AWS Cli
 ARG AWS_CLI_VERSION=1.22.32
 RUN python3 -m pip install --no-cache-dir awscli=="${AWS_CLI_VERSION}"
-
-## bash need to be installed for this instruction to work as expected
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ### Install Terraform CLI
 # Retrieve SHA256sum from https://releases.hashicorp.com/terraform/<TERRAFORM_VERSION>/terraform_<TERRAFORM_VERSION>_SHA256SUMS
@@ -58,6 +63,7 @@ RUN curl --silent --show-error --location --output /tmp/terraform.zip \
   && rm -f /tmp/terraform.zip \
   && terraform --version | grep "${TERRAFORM_VERSION}"
 
+### Install tfsec CLI
 ARG TFSEC_VERSION=0.63.1
 RUN curl --silent --show-error --location --output /tmp/tfsec \
     "https://github.com/tfsec/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64" \
@@ -65,26 +71,24 @@ RUN curl --silent --show-error --location --output /tmp/tfsec \
   && mv /tmp/tfsec /usr/local/bin/tfsec \
   && tfsec --version | grep "${TFSEC_VERSION}"
 
-
+### Install golangcilint CLI
 ARG GOLANGCILINT_VERSION=1.43.0
 RUN curl --silent --show-error --location --fail \
   https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
   | sh -s -- -b "/usr/local/bin" "v${GOLANGCILINT_VERSION}"
 
+### Install updatecli
+COPY --from=updatecli /usr/local/bin/updatecli /usr/local/bin/updatecli
+
 USER jenkins
 
-LABEL io.jenkins-infra.tools="golang,terraform,tfsec,packer,golangci-lint,aws-cli,yq"
+LABEL io.jenkins-infra.tools="golang,terraform,tfsec,packer,golangci-lint,aws-cli,yq,updatecli"
 LABEL io.jenkins-infra.tools.terraform.version="${TERRAFORM_VERSION}"
 LABEL io.jenkins-infra.tools.golang.version="${GO_VERSION}"
 LABEL io.jenkins-infra.tools.tfsec.version="${TFSEC_VERSION}"
-LABEL io.jenkins-infra.tools.packer="${PACKER_VERSION}"
+LABEL io.jenkins-infra.tools.packer.version="${PACKER_VERSION}"
 LABEL io.jenkins-infra.tools.golangci-lint.version="${GOLANGCILINT_VERSION}"
 LABEL io.jenkins-infra.tools.aws-cli.version="${AWS_CLI_VERSION}"
+LABEL io.jenkins-infra.tools.updatecli.version="${UPDATECLI_VERSION}"
 
-# WORKDIR /app
-
-# CMD ["/bin/bash"]
-
-# WORKDIR /home/jenkins
-
-# ENTRYPOINT ["/usr/local/bin/jenkins-agent"]
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/cst.yml
+++ b/cst.yml
@@ -2,7 +2,7 @@ schemaVersion: 2.0.0
 metadataTest:
   labels:
     - key: io.jenkins-infra.tools
-      value: "golang,terraform,tfsec,packer,golangci-lint,aws-cli,yq"
+      value: "golang,terraform,tfsec,packer,golangci-lint,aws-cli,yq,updatecli"
     - key: io.jenkins-infra.tools.terraform.version
       value: "1.0.11"
     - key: io.jenkins-infra.tools.golang.version
@@ -13,11 +13,16 @@ metadataTest:
       value: "1.43.0"
     - key: io.jenkins-infra.tools.aws-cli.version
       value: "1.22.32"
-    - key: io.jenkins-infra.tools.packer
+    - key: io.jenkins-infra.tools.packer.version
       value: "1.7.8"
+    - key: io.jenkins-infra.tools.updatecli.version
+      value: "v0.17.2"
   entrypoint: ["/usr/local/bin/jenkins-agent"]
   cmd: []
   workdir: "/home/jenkins"
+  user: jenkins
+
+# Test for binaries that are not defined in labels (for faster tests)
 fileExistenceTests:
   - name: 'Bash'
     path: '/bin/bash'
@@ -39,29 +44,10 @@ fileExistenceTests:
     path: '/usr/bin/unzip'
     shouldExist: true
     isExecutableBy: 'any'
-  - name: 'Terraform CLI'
-    path: '/usr/local/bin/terraform'
+  - name: 'yq'
+    path: '/usr/bin/yq'
     shouldExist: true
     isExecutableBy: 'any'
-  - name: 'tfsec CLI'
-    path: '/usr/local/bin/tfsec'
-    shouldExist: true
-    isExecutableBy: 'any'
-  - name: 'golangci-lint'
-    path: '/usr/local/bin/golangci-lint'
-    shouldExist: true
-    isExecutableBy: 'any'
-  - name: 'AWS CLI'
-    path: '/usr/bin/aws'
-    shouldExist: true
-    isExecutableBy: 'any'
-  - name: 'Terraform Archive must be cleaned up'
-    path: '/tmp/terraform.zip'
-    shouldExist: false
   - name: "Default user's home"
     path: '/home/jenkins'
     shouldExist: true
-fileContentTests:
-  - name: 'Default user exists with the correct UID/GID'
-    path: '/etc/passwd'
-    expectedContents: ['.*jenkins:x:1000:1000.*']


### PR DESCRIPTION
This PR closes #7 by adding updatecli in version 0.17.2.

It also cleans up instructions and test with 2 goals:

- As the test harness takes quite some time to run, removes low value tests (e.g. checking for binary that are already declared as label: chances are high that PR author have already installed and tested the binary if adding the label even if not 100% sure).
- Improve Dockerfile caching.

This PR depends on #15 