### PR TITLE
adding jenkins agent version monitoring by updatecli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ COPY --from=updatecli /usr/local/bin/updatecli /usr/local/bin/updatecli
 
 USER jenkins
 
-## trick to have it working again
+## As per https://docs.docker.com/engine/reference/builder/#scope, ARG need to be repeated for each scope
 ARG JENKINS_AGENT_VERSION=4.11-1-alpine-jdk11
 
 LABEL io.jenkins-infra.tools="golang,terraform,tfsec,packer,golangci-lint,aws-cli,yq,updatecli,jenkins-agent"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,12 @@
 ARG GO_VERSION=1.17.6
 ARG PACKER_VERSION=1.7.9
 ARG UPDATECLI_VERSION=v0.18.3
+ARG JENKINS_AGENT_VERSION=4.11-1-alpine-jdk11
+
 FROM golang:"${GO_VERSION}-alpine" AS gosource
 FROM hashicorp/packer:"${PACKER_VERSION}" AS packersource
 FROM updatecli/updatecli:${UPDATECLI_VERSION} AS updatecli
-
-FROM jenkins/inbound-agent:4.11-1-alpine-jdk11
+FROM jenkins/inbound-agent:"${JENKINS_AGENT_VERSION}"
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,8 @@ ARG JENKINS_AGENT_VERSION=4.11-1-alpine-jdk11
 
 FROM golang:"${GO_VERSION}-alpine" AS gosource
 FROM hashicorp/packer:"${PACKER_VERSION}" AS packersource
-FROM updatecli/updatecli:${UPDATECLI_VERSION} AS updatecli
+FROM updatecli/updatecli:"${UPDATECLI_VERSION}" AS updatecli
 FROM jenkins/inbound-agent:"${JENKINS_AGENT_VERSION}"
-
 USER root
 
 RUN apk add --no-cache \
@@ -83,7 +82,10 @@ COPY --from=updatecli /usr/local/bin/updatecli /usr/local/bin/updatecli
 
 USER jenkins
 
-LABEL io.jenkins-infra.tools="golang,terraform,tfsec,packer,golangci-lint,aws-cli,yq,updatecli"
+## trick to have it working again
+ARG JENKINS_AGENT_VERSION=4.11-1-alpine-jdk11
+
+LABEL io.jenkins-infra.tools="golang,terraform,tfsec,packer,golangci-lint,aws-cli,yq,updatecli,jenkins-agent"
 LABEL io.jenkins-infra.tools.terraform.version="${TERRAFORM_VERSION}"
 LABEL io.jenkins-infra.tools.golang.version="${GO_VERSION}"
 LABEL io.jenkins-infra.tools.tfsec.version="${TFSEC_VERSION}"
@@ -91,5 +93,6 @@ LABEL io.jenkins-infra.tools.packer.version="${PACKER_VERSION}"
 LABEL io.jenkins-infra.tools.golangci-lint.version="${GOLANGCILINT_VERSION}"
 LABEL io.jenkins-infra.tools.aws-cli.version="${AWS_CLI_VERSION}"
 LABEL io.jenkins-infra.tools.updatecli.version="${UPDATECLI_VERSION}"
+LABEL io.jenkins-infra.tools.jenkins-agent.version="${JENKINS_AGENT_VERSION}"
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/cst.yml
+++ b/cst.yml
@@ -2,7 +2,7 @@ schemaVersion: 2.0.0
 metadataTest:
   labels:
     - key: io.jenkins-infra.tools
-      value: "golang,terraform,tfsec,packer,golangci-lint,aws-cli,yq,updatecli"
+      value: "golang,terraform,tfsec,packer,golangci-lint,aws-cli,yq,updatecli,jenkins-agent"
     - key: io.jenkins-infra.tools.terraform.version
       value: "1.0.11"
     - key: io.jenkins-infra.tools.golang.version
@@ -17,6 +17,8 @@ metadataTest:
       value: "1.7.9"
     - key: io.jenkins-infra.tools.updatecli.version
       value: "v0.18.3"
+    - key: io.jenkins-infra.tools.jenkins-agent.version
+      value: "4.11.2-4"
   entrypoint: ["/usr/local/bin/jenkins-agent"]
   cmd: []
   workdir: "/home/jenkins"

--- a/cst.yml
+++ b/cst.yml
@@ -18,7 +18,7 @@ metadataTest:
     - key: io.jenkins-infra.tools.updatecli.version
       value: "v0.18.3"
     - key: io.jenkins-infra.tools.jenkins-agent.version
-      value: "4.11.2-4"
+      value: "4.11-1-alpine-jdk11"
   entrypoint: ["/usr/local/bin/jenkins-agent"]
   cmd: []
   workdir: "/home/jenkins"

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -45,6 +45,14 @@ conditions:
       file: "cst.yml"
       key: "metadataTest.labels[8].key"
       value: io.jenkins-infra.tools.jenkins-agent.version
+  checkDockerImagePublished:
+    name: "Is latest dockerfile docker-inbound-agent image published?"
+    kind: dockerImage
+    sourceID: lastVersion
+    spec:
+      image: "jenkins/inbound-agent" # How can I add the version that is above here ?
+      architecture: "amd64"
+      ## tag comes from the source
 
 
 targets:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -24,6 +24,8 @@ sources:
       username: "{{ .github.username }}"
       versionFilter:
         kind: latest
+      transformers:
+        - addPrefix: "-alpine-jdk11"
 
 conditions:
   testDockerfile:
@@ -41,7 +43,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[7].key"
+      key: "metadataTest.labels[8].key"
       value: io.jenkins-infra.tools.jenkins-agent.version
 
 
@@ -52,8 +54,8 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[7].value"
-    scmID: default
+      key: "metadataTest.labels[8].value"
+    # scmID: default
   updateDockerfileVersion:
     name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"
     sourceID: lastVersion
@@ -63,7 +65,7 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "JENKINS_AGENT_VERSION"
-    scmID: default
+    # scmID: default
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -1,0 +1,77 @@
+---
+title: "Bump jenkins agent version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubRelease
+    name: Get the latest jenkins-agent version
+    spec:
+      owner: "jenkinsci"
+      repository: "docker-inbound-agent"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+
+conditions:
+  testDockerfile:
+    name: "Does the Dockerfile have an ARG instruction which key is JENKINS_AGENT_VERSION?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "JENKINS_AGENT_VERSION"
+  testTestHarness:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.jenkins-agent.version?"
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[7].key"
+      value: io.jenkins-infra.tools.jenkins-agent.version
+
+
+targets:
+  updateTestVersion:
+    name: "Update the test harness"
+    sourceID: lastVersion
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[7].value"
+    scmID: default
+  updateDockerfileVersion:
+    name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"
+    sourceID: lastVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "JENKINS_AGENT_VERSION"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateTestVersion
+      - updateDockerfileVersion
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -31,7 +31,7 @@ conditions:
   testDockerfile:
     name: "Does the Dockerfile have an ARG instruction which key is JENKINS_AGENT_VERSION?"
     kind: dockerfile
-    #disablesourceinput: true
+    disablesourceinput: true
     spec:
       file: Dockerfile
       instruction:
@@ -52,20 +52,24 @@ targets:
     name: "Update the test harness"
     sourceID: lastVersion
     kind: yaml
+    transformers:
+      - addSuffix: "-alpine-jdk11"
     spec:
       file: "cst.yml"
       key: "metadataTest.labels[8].value"
-    # scmID: default
+    scmID: default
   updateDockerfileVersion:
     name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"
     sourceID: lastVersion
     kind: dockerfile
+    transformers:
+      - addSuffix: "-alpine-jdk11"
     spec:
       file: Dockerfile
       instruction:
         keyword: "ARG"
         matcher: "JENKINS_AGENT_VERSION"
-    # scmID: default
+    scmID: default
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -25,13 +25,13 @@ sources:
       versionFilter:
         kind: latest
       transformers:
-        - addPrefix: "-alpine-jdk11"
+        - addSuffix: "-alpine-jdk11"
 
 conditions:
   testDockerfile:
     name: "Does the Dockerfile have an ARG instruction which key is JENKINS_AGENT_VERSION?"
     kind: dockerfile
-    disablesourceinput: true
+    #disablesourceinput: true
     spec:
       file: Dockerfile
       instruction:


### PR DESCRIPTION
adding the jenkins agent in an arg to monitor it's version with updatecli, within the harness test too.
Closing #8 