### PR TITLE
fix version check on coreutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
   # Used to download binaries (implies the package "ca-certificates" as a dependency)
   curl=~7 \
   # Required to ensure GNU conventions for tools like "date"
-  coreutils=~8 \
+  coreutils=~9 \
   # Dev. Tooling packages (e.g. tools provided by this image installable through Alpine Linux Packages)
   git=~2\
   # jq for the json in /cleanup/aws.sh


### PR DESCRIPTION
as per validating this PR #28 the version of coreutil was too low in the acceptance rule for the new alpine version. @dduportal peered on this.
