### PR TITLE
chore(release-drafter) avoid multiple "next" draft releases

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
   release:
 
+# Only allow 1 release-drafter build at a time to avoid creating multiple "next" releases
+concurrency: "release-drafter"
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
twin of https://github.com/jenkins-infra/docker-helmfile/pull/115