### PR TITLE
fix(updatecli): correct owner in updatecli/values.yaml

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -4,5 +4,5 @@ github:
   username: "jenkins-infra-bot"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"
-  owner: "dduportal"
+  owner: "jenkins-infra"
   repository: "docker-hashicorp-tools"


### PR DESCRIPTION
I was wondering why aws-cli [was updated to 1.25.90] while [there are 1.26.x versions available](https://github.com/aws/aws-cli/tags), then when consulting the logs I've noticed something fishy ^^