### PR TITLE
💥 feat: bump terraform to `1.4.4`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN python3 -m pip install --no-cache-dir awscli=="${AWS_CLI_VERSION}"
 # For instance: "
 # TERRAFORM_VERSION=X.YY.Z
 # curl -sSL https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_$TERRAFORM_VERSION_SHA256SUMS | grep linux_amd64
-ARG TERRAFORM_VERSION=1.1.9
+ARG TERRAFORM_VERSION=1.3.3
 RUN curl --silent --show-error --location --output /tmp/terraform.zip \
   "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
   && unzip /tmp/terraform.zip -d /usr/local/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN python3 -m pip install --no-cache-dir awscli=="${AWS_CLI_VERSION}"
 # For instance: "
 # TERRAFORM_VERSION=X.YY.Z
 # curl -sSL https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_$TERRAFORM_VERSION_SHA256SUMS | grep linux_amd64
-ARG TERRAFORM_VERSION=1.3.3
+ARG TERRAFORM_VERSION=1.4.4
 RUN curl --silent --show-error --location --output /tmp/terraform.zip \
   "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
   && unzip /tmp/terraform.zip -d /usr/local/bin \

--- a/cst.yml
+++ b/cst.yml
@@ -4,7 +4,7 @@ metadataTest:
     - key: io.jenkins-infra.tools
       value: "aws-cli,azure-cli,golang,golangci-lint,jenkins-inbound-agent,packer,terraform,tfsec,updatecli,yq"
     - key: io.jenkins-infra.tools.terraform.version
-      value: "1.1.9"
+      value: "1.3.3"
     - key: io.jenkins-infra.tools.golang.version
       value: "1.19.2"
     - key: io.jenkins-infra.tools.tfsec.version

--- a/cst.yml
+++ b/cst.yml
@@ -4,7 +4,7 @@ metadataTest:
     - key: io.jenkins-infra.tools
       value: "aws-cli,azure-cli,golang,golangci-lint,jenkins-inbound-agent,packer,terraform,tfsec,updatecli,yq"
     - key: io.jenkins-infra.tools.terraform.version
-      value: "1.3.3"
+      value: "1.4.4"
     - key: io.jenkins-infra.tools.golang.version
       value: "1.19.5"
     - key: io.jenkins-infra.tools.tfsec.version

--- a/updatecli/updatecli.d/terraform.yml
+++ b/updatecli/updatecli.d/terraform.yml
@@ -24,6 +24,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: semver
+        pattern: "~1.4"
     transformers:
       - trimprefix: "v"
 

--- a/updatecli/updatecli.d/terraform.yml
+++ b/updatecli/updatecli.d/terraform.yml
@@ -23,9 +23,7 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionfilter:
-        kind: regex
-        # Stick to versions 1.1.x of terraform
-        pattern: 'v1\.1\.(\d*)$'
+        kind: semver
     transformers:
       - trimprefix: "v"
 


### PR DESCRIPTION
This PR introduces 2 changes:

- 💥 feat: bump terraform to ~`1.3.3`~ `1.4.4` (from `1.1.9`)
- Change the updatecli manifest tracking the Terraform version to always check the latest semver version. The goal is to avoid waiting too much for Terraform minor (or major) upgrades: all of our project have a guardrail with the Terraform version being constrained.