### PR TITLE
chore(updatecli) track trivy and doctl + fix skipped manifests

### DIFF
--- a/updatecli/updatecli.d/awscli.yml
+++ b/updatecli/updatecli.d/awscli.yml
@@ -43,7 +43,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[5].key"
+      key: "metadataTest.labels[4].key"
       value: io.jenkins-infra.tools.aws-cli.version
 
 targets:
@@ -53,7 +53,7 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[5].value"
+      key: "metadataTest.labels[4].value"
     scmid: default
   updateDockerfileArgVersion:
     name: "Update the value of ARG AWS_CLI_VERSION in the Dockerfile"

--- a/updatecli/updatecli.d/doctl.yml
+++ b/updatecli/updatecli.d/doctl.yml
@@ -71,5 +71,6 @@ actions:
     title: Bump the `doctl` CLI version to {{ source "doctl" }}
     spec:
       labels:
+        - enhancement
         - dependencies
         - doctl

--- a/updatecli/updatecli.d/doctl.yml
+++ b/updatecli/updatecli.d/doctl.yml
@@ -1,0 +1,75 @@
+---
+name: Bump the `doctl` CLI version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  doctl:
+    kind: githubrelease
+    name: Get the latest doctl version
+    spec:
+      owner: "digitalocean"
+      repository: "doctl"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+
+conditions:
+  dockerfileArgDoctlVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is DOCTL_VERSION?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "DOCTL_VERSION"
+  testCstDoctlVersion:
+    name: "Update the value of DOCTL_VERSION in the test harness"
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[9].key"
+      value: io.jenkins-infra.tools.doctl.version
+
+targets:
+  updateCst:
+    name: "Update the value of DOCTL_VERSION in the test harness"
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[9].value"
+    scmid: default
+  updateDockerfile:
+    name: "Update the value of ARG DOCTL_VERSION in the Dockerfile"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "DOCTL_VERSION"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump the `doctl` CLI version to {{ source "doctl" }}
+    spec:
+      labels:
+        - dependencies
+        - doctl

--- a/updatecli/updatecli.d/golangcilint.yml
+++ b/updatecli/updatecli.d/golangcilint.yml
@@ -43,7 +43,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[4].key"
+      key: "metadataTest.labels[3].key"
       value: io.jenkins-infra.tools.golangci-lint.version
 
 targets:
@@ -53,7 +53,7 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[4].value"
+      key: "metadataTest.labels[3].value"
     scmid: default
   updateDockerfileArgVersion:
     name: "Update the value of ARG GOLANGCILINT_VERSION in the Dockerfile"

--- a/updatecli/updatecli.d/jenkins-inbound-agent.yml
+++ b/updatecli/updatecli.d/jenkins-inbound-agent.yml
@@ -24,8 +24,8 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        ## not the JDK7 version - regex from https://stackoverflow.com/questions/16397471/regex-for-string-not-ending-with-given-suffix/16397502#16397502
-        pattern: '.*[^-][^j][^d][^k][^7]$'
+        ## not the JDK8 version - regex from https://stackoverflow.com/questions/16398471/regex-for-string-not-ending-with-given-suffix/16398502#16398502
+        pattern: '.*[^-][^j][^d][^k][^8]$'
 
 conditions:
   testDockerfile:

--- a/updatecli/updatecli.d/jenkins-inbound-agent.yml
+++ b/updatecli/updatecli.d/jenkins-inbound-agent.yml
@@ -24,8 +24,8 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        ## not the JDK8 version - regex from https://stackoverflow.com/questions/16398471/regex-for-string-not-ending-with-given-suffix/16398502#16398502
-        pattern: '.*[^-][^j][^d][^k][^8]$'
+        ## not the JDK7 version - regex from https://stackoverflow.com/questions/16397471/regex-for-string-not-ending-with-given-suffix/16397502#16397502
+        pattern: '.*[^-][^j][^d][^k][^7]$'
 
 conditions:
   testDockerfile:
@@ -43,7 +43,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[8].key"
+      key: "metadataTest.labels[7].key"
       value: io.jenkins-infra.tools.jenkins-inbound-agent.version
   checkDockerImagePublished:
     name: "Is latest dockerfile docker-inbound-agent image published?"
@@ -63,7 +63,7 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[8].value"
+      key: "metadataTest.labels[7].value"
     scmid: default
   updateDockerfileVersion:
     name: "Update the value of ARG JENKINS_INBOUND_AGENT_VERSION in the Dockerfile"

--- a/updatecli/updatecli.d/trivy.yaml
+++ b/updatecli/updatecli.d/trivy.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump the `az` CLI version
+name: Bump the `trivy` CLI version
 
 scms:
   default:
@@ -14,67 +14,65 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  getAzCliVersion:
+  lastReleaseVersion:
     kind: githubrelease
-    name: Get the latest azure-cli version
+    name: Get the latest `trivy` CLI version
     spec:
-      owner: "Azure"
-      repository: "azure-cli"
+      owner: aquasecurity
+      repository: trivy
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionfilter:
-        kind: regex
-        ## Latest stable x.y.z version
-        pattern: 'azure-cli-(\d*)\.(\d*)\.(\d*)$'
+        kind: semver
     transformers:
-      - trimprefix: "azure-cli-"
+      - trimprefix: v
 
 conditions:
-  testDockerfileArgAzCliVersion:
-    name: "Does the Dockerfile have an ARG instruction which key is AZ_CLI_VERSION?"
+  testDockerfileArgTrivycliVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is TRIVY_VERSION?"
     kind: dockerfile
     disablesourceinput: true
     spec:
       file: Dockerfile
       instruction:
         keyword: "ARG"
-        matcher: "AZ_CLI_VERSION"
-  testCstAzCliVersion:
-    name: "Does the test harness checks for a label io.jenkins-infra.tools.azure-cli.version?"
+        matcher: "TRIVY_VERSION"
+  testCstTrivycliVersion:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.trivy.version?"
     kind: yaml
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[8].key"
-      value: io.jenkins-infra.tools.azure-cli.version
+      key: "metadataTest.labels[10].key"
+      value: io.jenkins-infra.tools.trivy.version
 
 targets:
   updateCstVersion:
-    name: "Update the label io.jenkins-infra.tools.azure-cli.version in the test harness"
-    sourceid: getAzCliVersion
+    name: "Update the label io.jenkins-infra.tools.trivy.version in the test harness"
+    sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[8].value"
+      key: "metadataTest.labels[10].value"
     scmid: default
   updateDockerfileArgVersion:
-    name: "Update the value of ARG AZ_CLI_VERSION in the Dockerfile"
-    sourceid: getAzCliVersion
+    name: "Update the value of ARG TRIVY_VERSION in the Dockerfile"
+    sourceid: lastReleaseVersion
     kind: dockerfile
     spec:
       file: Dockerfile
       instruction:
         keyword: "ARG"
-        matcher: "AZ_CLI_VERSION"
+        matcher: "TRIVY_VERSION"
     scmid: default
 
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump the `az` CLI version to {{ source "getAzCliVersion" }}
+    title: Bump the `trivy` CLI version to {{ source "lastReleaseVersion" }}
     spec:
       labels:
+        - enhancement
         - dependencies
-        - azure-cli
-        - az
+        - trivy


### PR DESCRIPTION
This PR fixes the current dependencies tracking (which uses `updatecli`):

- Add manifests to track `trivy` (fixes failing builds on `main` branch and blocks #354) and `doctl`
- Fix the manifest  referencing wrong CST items

Once merged, this change expects to propose updates for 6 dependencies while 4 are up to date