### PR TITLE
Revert "Bump Jenkins Inbound Agent Version to 3180.v3dd999d24861-2"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG GO_VERSION=1.21.3
 ARG PACKER_VERSION=1.9.4
 ARG UPDATECLI_VERSION=v0.63.0
-ARG JENKINS_INBOUND_AGENT_VERSION=3180.v3dd999d24861-2
+ARG JENKINS_INBOUND_AGENT_VERSION=3148.v532a_7e715ee3-7
 
 FROM golang:"${GO_VERSION}-alpine" AS gosource
 FROM hashicorp/packer:"${PACKER_VERSION}" AS packersource
@@ -98,7 +98,7 @@ RUN curl --silent --show-error --location --output /tmp/doctl.tar.gz\
 USER jenkins
 
 ## As per https://docs.docker.com/engine/reference/builder/#scope, ARG need to be repeated for each scope
-ARG JENKINS_INBOUND_AGENT_VERSION=3180.v3dd999d24861-2
+ARG JENKINS_INBOUND_AGENT_VERSION=3148.v532a_7e715ee3-7
 
 LABEL io.jenkins-infra.tools="aws-cli,azure-cli,doctl,golang,golangci-lint,jenkins-inbound-agent,packer,terraform,trivy,updatecli,yq"
 LABEL io.jenkins-infra.tools.terraform.version="${TERRAFORM_VERSION}"

--- a/cst.yml
+++ b/cst.yml
@@ -16,7 +16,7 @@ metadataTest:
     - key: io.jenkins-infra.tools.updatecli.version
       value: v0.63.0
     - key: io.jenkins-infra.tools.jenkins-inbound-agent.version
-      value: 3180.v3dd999d24861-2
+      value: 3148.v532a_7e715ee3-7
     - key: io.jenkins-infra.tools.azure-cli.version
       value: 2.52.0
     - key: io.jenkins-infra.tools.doctl.version


### PR DESCRIPTION
Reverts jenkins-infra/docker-hashicorp-tools#360

Ref. https://github.com/jenkins-infra/jenkins-infra/pull/3126